### PR TITLE
Remove object class param

### DIFF
--- a/run/run_nf_covid.py
+++ b/run/run_nf_covid.py
@@ -11,7 +11,7 @@ from run.constants import (
 )
 
 
-class RunNfCovid(object):
+class RunNfCovid:
     """Instances of this class represent a long covid pipeline run.
     """
     def __init__(


### PR DESCRIPTION
Since I'm not worried about python 2 compatibility, this can be dropped